### PR TITLE
Add test for hsl alpha in attribute/color

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -160,12 +160,16 @@ describe('common', () => {
         var attributes2 = transforms["attribute/color"].transformer({
           value: "rgba(170,170,170,0.6)"
         });
+        var attributes3 = transforms["attribute/color"].transformer({
+          value: "hsl(332, 98%, 36%, 0.97)"
+        });
         expect(attributes).toHaveProperty('rgb.a', 0.6);
         expect(attributes).toHaveProperty('rgb.r', 170);
         expect(attributes).toHaveProperty('hsl.s', 0);
         expect(attributes2).toHaveProperty('rgb.a', 0.6);
         expect(attributes2).toHaveProperty('rgb.r', 170);
         expect(attributes2).toHaveProperty('hsl.s', 0);
+        expect(attributes3).toHaveProperty('hsl.a', 0.97);
       });
     });
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixing `attribute/color` so that it work with `hsl()` colors that have an alpha channel.

The issue lies with `tinycolor2` that does not recognise that syntax and fixes the alpha to `1` if `hsl()` is used. According to the CSS spec, you can specify a fourth argument, so both `hsl` and `hsla` should work.

Creating this PR as a draft and I will update it when my changes have landed on `tinycolor2`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
