### PR TITLE
Add static option to any.swift.template

### DIFF
--- a/__tests__/formats/__snapshots__/swiftFile.test.js.snap
+++ b/__tests__/formats/__snapshots__/swiftFile.test.js.snap
@@ -72,3 +72,39 @@ public struct StyleDictionary {
 }
 "
 `;
+
+exports[`formats ios-swift/any.swift with static should match snapshot 1`] = `
+"
+//
+// __output/
+//
+
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
+
+
+import UIKit
+
+public class StyleDictionary {
+    public static let colorBaseRed = UIColor(red: 1.000, green: 0.000, blue: 0.000, alpha: 1)
+}
+"
+`;
+
+exports[`formats ios-swift/any.swift without static should match snapshot 1`] = `
+"
+//
+// __output/
+//
+
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
+
+
+import UIKit
+
+public class StyleDictionary {
+    public let colorBaseRed = UIColor(red: 1.000, green: 0.000, blue: 0.000, alpha: 1)
+}
+"
+`;

--- a/__tests__/formats/swiftFile.test.js
+++ b/__tests__/formats/swiftFile.test.js
@@ -89,6 +89,24 @@ describe('formats', () => {
       }), {}, file)).toMatchSnapshot();
     });
 
+    it('without static should match snapshot', () => {
+      file.options.static = false
+      expect(format(createFormatArgs({
+        dictionary,
+        file,
+        platform: {}
+      }), {}, file)).toMatchSnapshot();
+    });
+
+    it('with static should match snapshot', () => {
+      file.options.static = true
+      expect(format(createFormatArgs({
+        dictionary,
+        file,
+        platform: {}
+      }), {}, file)).toMatchSnapshot();
+    });
+
   });
 
 });

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1563,7 +1563,10 @@ Creates a Swift implementation file of a class with values. It adds default `cla
 <tr>
     <td>options</td><td><code>Object</code></td><td></td><td></td>
     </tr><tr>
-    <td>[options.accessControl]</td><td><code>String</code></td><td><code>public</code></td><td><p>Level of <a href="https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html">access</a> of the generated swift object</p>
+    <td>[options.accessControl]</td><td><code>String</code></td><td><code>public</code></td><td><p>Level of <a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol/">access</a> of the generated swift object</p>
+</td>
+    </tr><tr>
+    <td>[options.static]</td><td><code>Boolean</code></td><td><code>true</code></td><td><p>Type of property of the generated swift object</p>
 </td>
     </tr><tr>
     <td>[options.import]</td><td><code>Array.&lt;String&gt;</code></td><td><code>UIKit</code></td><td><p>Modules to import. Can be a string or array of strings</p>
@@ -1605,6 +1608,9 @@ Creates a Swift implementation file of an enum with values. It adds default `enu
     <td>options</td><td><code>Object</code></td><td></td><td></td>
     </tr><tr>
     <td>[options.accessControl]</td><td><code>String</code></td><td><code>public</code></td><td><p>Level of <a href="https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html">access</a> of the generated swift object</p>
+</td>
+    </tr><tr>
+    <td>[options.static]</td><td><code>Boolean</code></td><td><code>true</code></td><td><p>Type of property of the generated swift object</p>
 </td>
     </tr><tr>
     <td>[options.import]</td><td><code>Array.&lt;String&gt;</code></td><td><code>UIKit</code></td><td><p>Modules to import. Can be a string or array of strings</p>
@@ -1650,6 +1656,9 @@ accessControl: 'internal',
     <td>options</td><td><code>Object</code></td><td></td><td></td>
     </tr><tr>
     <td>[options.accessControl]</td><td><code>String</code></td><td><code>public</code></td><td><p>Level of <a href="https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html">access</a> of the generated swift object</p>
+</td>
+    </tr><tr>
+    <td>[options.static]</td><td><code>Boolean</code></td><td><code>true</code></td><td><p>Type of property of the generated swift object</p>
 </td>
     </tr><tr>
     <td>[options.import]</td><td><code>Array.&lt;String&gt;</code></td><td><code>UIKit</code></td><td><p>Modules to import. Can be a string or array of strings</p>

--- a/lib/common/formatHelpers/setSwiftFileProperties.js
+++ b/lib/common/formatHelpers/setSwiftFileProperties.js
@@ -49,6 +49,10 @@ function setSwiftFileProperties(options, objectType, transformGroup) {
     }
   }
 
+  if (typeof options.static === 'undefined') {
+    options.static = true;
+  }
+
   return options
 }
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -926,7 +926,8 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @memberof Formats
    * @kind member
    * @param {Object} options
-   * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html) of the generated swift object
+   * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/accesscontrol/) of the generated swift object
+   * @param {Boolean} [options.static=true] - Type of property of the generated swift object
    * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of strings
    * @param {String} [options.className] - The name of the generated Swift class
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
@@ -969,6 +970,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @kind member
    * @param {Object} options
    * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html) of the generated swift object
+   * @param {Boolean} [options.static=true] - Type of property of the generated swift object
    * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of strings
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @param {Boolean} [options.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
@@ -1016,6 +1018,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @kind member
    * @param {Object} options
    * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html) of the generated swift object
+   * @param {Boolean} [options.static=true] - Type of property of the generated swift object
    * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of strings
    * @param {String} [options.objectType=class] - The type of the generated Swift object
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date

--- a/lib/common/templates/ios-swift/any.swift.template
+++ b/lib/common/templates/ios-swift/any.swift.template
@@ -24,6 +24,6 @@
 
 <%= options.accessControl %><%= options.objectType %> <%= file.className %> {
     <%= allTokens.map(function(prop) {
-      return options.accessControl + 'static let ' + formatProperty(prop);
+      return options.accessControl + (options.static ? 'static ' : '') + 'let ' + formatProperty(prop);
     }).join('\n    ') %>
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Sometimes it is desirable to reference design tokens via a [KeyPath](https://developer.apple.com/documentation/swift/keypath) when using them from Swift. To support this, the generated token set would need to be instance properties and not static. This PR adds a `static` options for Swift classes, it defaults to `true` so all current deployment will continue working as is.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
